### PR TITLE
Register DeepKey itself better Documentation

### DIFF
--- a/zomes/dpki/code/src/dpki_trait/mod.rs
+++ b/zomes/dpki/code/src/dpki_trait/mod.rs
@@ -28,7 +28,6 @@ struct SetAuthParams {
 }
 
 pub fn init(params: String) -> ZomeApiResult<HashString> {
-    hdk::debug(format!("AGENT KEY >>>>>>>  {:}", AGENT_ADDRESS.clone()).to_string())?;
     // Checking is initialized
     if !is_initialized()? {
         // DANGER :: Used unrap
@@ -58,6 +57,8 @@ pub fn init(params: String) -> ZomeApiResult<HashString> {
             None => match init_params.first_deepkey_agent {
                 Some(_) => {
                     hdk::debug(format!("*******ToDo for FDA*************"))?;
+                    // We need to Handshake
+
                 }
                 None => return Err(ZomeApiError::from("Error".to_string())),
             },
@@ -70,7 +71,7 @@ pub fn init(params: String) -> ZomeApiResult<HashString> {
             Ok(a) => Ok(a),
             Err(e) => Err(e),
         }
-    //TODO: Register this DeepKey Agent
+    //TODO: Register this DeepKey Agent Keys in this DeepKey instance
     } else {
         Err(ZomeApiError::Internal(
             "INIT ERROR: Already Initialized".to_string(),

--- a/zomes/dpki/code/src/dpki_trait/mod.rs
+++ b/zomes/dpki/code/src/dpki_trait/mod.rs
@@ -71,7 +71,10 @@ pub fn init(params: String) -> ZomeApiResult<HashString> {
             Ok(a) => Ok(a),
             Err(e) => Err(e),
         }
+
     //TODO: Register this DeepKey Agent Keys in this DeepKey instance
+    // hdk::update_agent() - This will update and register the key into `deepkey`
+
     } else {
         Err(ZomeApiError::Internal(
             "INIT ERROR: Already Initialized".to_string(),

--- a/zomes/dpki/code/src/key_registration/handlers.rs
+++ b/zomes/dpki/code/src/key_registration/handlers.rs
@@ -26,7 +26,23 @@ fn choose_key_type(key_type: &AppKeyType) -> KeyType {
     }
 }
 
-pub fn register_key(
+pub fn handle_create_key_registration(
+    derivation_index: u64,
+    key_type: AppKeyType,
+    context: String,
+) -> ZomeApiResult<Address> {
+    // Validate the key and sign the key wit the auth key
+    let derived_key = derive_key(derivation_index, &context, choose_key_type(&key_type))?
+        .trim_matches('"')
+        .to_owned();
+
+    hdk::debug(format!("A Key was created: {}", derived_key.clone()))?;
+
+    register_key(derived_key, derivation_index, key_type, context)
+}
+
+
+fn register_key(
     key: String,
     derivation_index: u64,
     key_type: AppKeyType,
@@ -72,21 +88,6 @@ pub fn register_key(
         }
         Err(e) => Err(e),
     }
-}
-
-pub fn handle_create_key_registration(
-    derivation_index: u64,
-    key_type: AppKeyType,
-    context: String,
-) -> ZomeApiResult<Address> {
-    // Validate the key and sign the key wit the auth key
-    let derived_key = derive_key(derivation_index, &context, choose_key_type(&key_type))?
-        .trim_matches('"')
-        .to_owned();
-
-    hdk::debug(format!("A Key was created: {}", derived_key.clone()))?;
-
-    register_key(derived_key, derivation_index, key_type, context)
 }
 
 pub fn update_key(

--- a/zomes/dpki/code/src/key_registration/handlers.rs
+++ b/zomes/dpki/code/src/key_registration/handlers.rs
@@ -26,21 +26,16 @@ fn choose_key_type(key_type: &AppKeyType) -> KeyType {
     }
 }
 
-pub fn handle_create_key_registration(
+pub fn register_key(
+    key: String,
     derivation_index: u64,
     key_type: AppKeyType,
-    context: String,
-) -> ZomeApiResult<Address> {
-    // Validate the key and sign the key wit the auth key
-    let derived_key = derive_key(derivation_index, &context, choose_key_type(&key_type))?
-        .trim_matches('"')
-        .to_owned();
-    let derived_key_hashstring = HashString::from(derived_key.to_owned());
-
-    hdk::debug(format!("A Key was created: {}", derived_key.clone()))?;
+    context: String
+) -> Result<Address, ZomeApiError>{
+    let derived_key_hashstring = HashString::from(key.to_owned());
 
     //Get the Auth Kye ID
-    let auth_key_signing_keys = sign_key_by_authorization_key(derived_key)?;
+    let auth_key_signing_keys = sign_key_by_authorization_key(key)?;
 
     // Registering the Key
     let key_registration = KeyRegistration {
@@ -77,6 +72,21 @@ pub fn handle_create_key_registration(
         }
         Err(e) => Err(e),
     }
+}
+
+pub fn handle_create_key_registration(
+    derivation_index: u64,
+    key_type: AppKeyType,
+    context: String,
+) -> ZomeApiResult<Address> {
+    // Validate the key and sign the key wit the auth key
+    let derived_key = derive_key(derivation_index, &context, choose_key_type(&key_type))?
+        .trim_matches('"')
+        .to_owned();
+
+    hdk::debug(format!("A Key was created: {}", derived_key.clone()))?;
+
+    register_key(derived_key, derivation_index, key_type, context)
 }
 
 pub fn update_key(


### PR DESCRIPTION
This PR register the `deepkey` instance keys as `Key_Registration` Entry.

This will take the key that the `deepkey` instance is using which has not been registered in `deepkey`.
So we need to make a KeyRegistration Entry and then register the metadata (`AppKey`).